### PR TITLE
Improve Github Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
         key: ${{ steps.caches.outputs.cache_key }}
         path: |
           ${{ github.workspace }}/Spout2
-          ${{ github.workspace }}/godot-cpp
+          ${{ github.workspace }}/scons_cache
     - name: Install cmake
       uses: lukka/get-cmake@fix-issue-123
     - name: Install Python
@@ -41,6 +41,8 @@ jobs:
         cmake --build . --clean-first
     - name: Build spout-gd extension
       run: scons target=${{ matrix.release }}
+      env:
+        SCONS_CACHE: ${{ github.workspace }}/scons_cache
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:
@@ -65,11 +67,10 @@ jobs:
         merge-multiple: true      
     - name: prepare for packaging
       run: |
-        ls artifacts
         mkdir release\addons\spout-gd
-        cp artifacts/spout_gd.windows.template_release.dll release\addons\spout-gd
-        cp artifacts/spout_gd.windows.template_debug.dll release\addons\spout-gd
-        cp artifacts/SpoutLibrary.dll release\addons\spout-gd
+        cp artifacts/out/spout_gd.windows.template_release.dll release\addons\spout-gd
+        cp artifacts/out/spout_gd.windows.template_debug.dll release\addons\spout-gd
+        cp artifacts/Spout2/Binaries/x64/SpoutLibrary.dll release\addons\spout-gd
         cp artifacts/spout_gd.gdextension release\addons\spout-gd
     - name: save artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,9 +42,9 @@ jobs:
     - name: Build spout-gd extension
       run: scons target=${{ matrix.release }}
     - name: save artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: spout2_${{ matrix.release }}
+        name: spout_gd-${{ matrix.release }}
         path: |
           out/spout_gd.windows.${{ matrix.release }}.dll
           Spout2/Binaries/x64/SpoutLibrary.dll
@@ -53,7 +53,7 @@ jobs:
   release:
     name: Release Library
     needs: [build]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -61,14 +61,16 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: artifacts
+        pattern: spout_gd-*
         merge-multiple: true      
     - name: prepare for packaging
       run: |
+        ls artifacts
         mkdir release\addons\spout-gd
-        copy artifacts/spout_gd.windows.template_release.dll release\addons\spout-gd
-        copy artifacts/spout_gd.windows.template_debug.dll release\addons\spout-gd
-        copy artifacts/SpoutLibrary.dll release\addons\spout-gd
-        copy artifacts/spout_gd.gdextension release\addons\spout-gd
+        cp artifacts/spout_gd.windows.template_release.dll release\addons\spout-gd
+        cp artifacts/spout_gd.windows.template_debug.dll release\addons\spout-gd
+        cp artifacts/SpoutLibrary.dll release\addons\spout-gd
+        cp artifacts/spout_gd.gdextension release\addons\spout-gd
     - name: save artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,14 +1,28 @@
 run-name: Build Spout-gd Extension
 on: push
+env:
+  project: spout_gd
 jobs:
   build:
-    name: Build library
-    runs-on: windows-latest
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        release: ['template_debug', 'template_release']
+        include:
+          - identifier: windows-debug
+            name: Windows Debug
+            runner: windows-latest
+            target: template_debug
+            platform: windows
+            arch: x86_64
+          - identifier: windows-release
+            name: Windows Release
+            runner: windows-latest
+            target: template_release
+            platform: windows
+            arch: x86_64
     env:
-      SCONS_CACHE: ${{ github.workspace }}/scons_cache/${{ matrix.release }}
+      SCONS_CACHE: ${{ github.workspace }}/scons_cache/${{ matrix.identifier }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -41,21 +55,26 @@ jobs:
       run: |
         cmake -DSKIP_INSTALL_ALL=OFF -DSKIP_INSTALL_HEADERS=OFF -DSKIP_INSTALL_LIBRARIES=OFF -DSPOUT_BUILD_LIBRARY=ON --fresh .
         cmake --build . --clean-first
-    - name: Build spout-gd extension
-      run: scons target=${{ matrix.release }}
+    - name: Build extension
+      run: scons target=${{ matrix.target }}
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:
-        name: spout_gd-${{ matrix.release }}
+        name: ${{ env.project }}.${{ matrix.platform }}.${{ matrix.arch }}.${{ matrix.target }}
         path: |
-          out/spout_gd.windows.${{ matrix.release }}.dll
+          out/${{ env.project }}.${{ matrix.platform }}.${{ matrix.target }}.dll
           Spout2/Binaries/x64/SpoutLibrary.dll
-          spout_gd.gdextension
+          ${{ env.project }}.gdextension
       
   release:
     name: Release Library
     needs: [build]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - platform: windows
+            arch: x86_64
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -63,22 +82,22 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: artifacts
-        pattern: spout_gd-*
+        pattern: ${{ env.project }}.${{ matrix.platform }}.${{ matrix.arch }}.*
         merge-multiple: true      
     - name: prepare for packaging
       run: |
-        mkdir -p release/addons/spout-gd
-        cp artifacts/out/spout_gd.windows.template_release.dll release/addons/spout-gd
-        cp artifacts/out/spout_gd.windows.template_debug.dll release/addons/spout-gd
-        cp artifacts/Spout2/Binaries/x64/SpoutLibrary.dll release/addons/spout-gd
-        cp artifacts/spout_gd.gdextension release/addons/spout-gd
+        mkdir -p release/addons/${{ env.project }}
+        cp artifacts/out/${{ env.project }}.${{ matrix.platform }}.template_release.dll release/addons/${{ env.project }}
+        cp artifacts/out/${{ env.project }}.${{ matrix.platform }}.template_debug.dll release/addons/${{ env.project }}
+        cp artifacts/Spout2/Binaries/x64/SpoutLibrary.dll release/addons/${{ env.project }}
+        cp artifacts/${{ env.project }}.gdextension release/addons/${{ env.project }}
     - name: save artifact
       uses: actions/upload-artifact@v3
       with:
-        name: spout-gd.zip
+        name: ${{ env.project }}.${{ matrix.platform }}.${{ matrix.arch }}
         path: release
     - name: push release
       if: ${{ github.ref == 'refs/heads/main' }}
       uses: ncipollo/release-action@v1
       with:
-        artifacts: spout-gd.zip
+        artifacts: ${{ env.project }}.${{ matrix.platform }}.${{ matrix.arch }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,8 +76,7 @@ jobs:
           ${{ env.project }}.gdextension
           README.md
       
-  release:
-    name: Release Library
+  package:
     needs: [build]
     runs-on: ubuntu-latest
     strategy:
@@ -101,12 +100,23 @@ jobs:
         cp artifacts/${{ env.project }}.gdextension release/addons/${{ env.project }}
         cp artifacts/README.md release/addons/${{env.project}}
     - name: save artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.project }}.${{ matrix.platform }}.${{ matrix.arch }}
         path: release
-    - name: push release
-      if: ${{ github.ref == 'refs/heads/main' }}
-      uses: ncipollo/release-action@v1
-      with:
-        artifacts: ${{ env.project }}.${{ matrix.platform }}.${{ matrix.arch }}
+        
+  release:
+    needs: [package]
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - name: load artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: ${{ env.project }}.*.*
+      - name: push release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: |
+            ${{ env.project }}.windows.x86_64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,17 +12,16 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: 'true'
-    - name: Check Spout version
+    - name: Check Cache versions
       id: caches
+      shell: bash
       run: |
-        "C:\Program Files\Git\bin\git.exe" rev-parse HEAD:Spout2
-        echo "spout_version=$("C:\Program Files\Git\bin\git.exe" rev-parse HEAD:Spout2)" >> $GITHUB_OUTPUT
-        echo "gdcpp_version=$("C:\Program Files\Git\bin\git.exe" rev-parse HEAD:godot-cpp)" >> $GITHUB_OUTPUT
-    - name: Cache Spout build
+        echo "cache_key=$(git rev-parse HEAD:Spout2):$(git rev-parse HEAD:godot-cpp)" >> $GITHUB_OUTPUT
+    - name: Cache Dependency Builds
       id: cache
       uses: actions/cache@v4
       with:
-        key: "${{ steps.caches.outputs.spout_version }}:${{steps.caches.outputs.gdcpp_version}}"
+        key: ${{ steps.caches.outputs.cache_key }}
         path: |
           ${{ github.workspace }}/Spout2
           ${{ github.workspace }}/godot-cpp

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-run-name: Build Spout-gd Extension
+name: Build Project
 on: push
 env:
   project: spout_gd

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,15 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: 'true'
+    - id: caches
+      run: |
+        echo "spout_version=${git rev-parse HEAD:Spout2}" >> $GITHUB_OUTPUT
+    - name: Cache Spout build
+      id: cache
+      uses: actions/cache@v4
+      with:
+        key: ${{ steps.caches.outputs.spout_version }}
+        path: ${{github.workspace}}/Spout2/Binaries/x64
     - name: Install cmake
       uses: lukka/get-cmake@fix-issue-123
     - name: Install Python
@@ -18,6 +27,7 @@ jobs:
     - name: Install scons
       run: pip install scons
     - name: Build Spout Library
+      if: steps.cache.outputs.cache-hit != 'true'
       working-directory: Spout2
       run: |
         cmake -DSKIP_INSTALL_ALL=OFF -DSKIP_INSTALL_HEADERS=OFF -DSKIP_INSTALL_LIBRARIES=OFF -DSPOUT_BUILD_LIBRARY=ON --fresh .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,6 +74,7 @@ jobs:
           out/${{ env.project }}.${{ matrix.platform }}.${{ matrix.target }}.dll
           Spout2/Binaries/x64/SpoutLibrary.dll
           ${{ env.project }}.gdextension
+          README.md
       
   release:
     name: Release Library
@@ -85,8 +86,6 @@ jobs:
           - platform: windows
             arch: x86_64
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
     - name: load artifacts
       uses: actions/download-artifact@v4
       with:
@@ -100,6 +99,7 @@ jobs:
         cp artifacts/out/${{ env.project }}.${{ matrix.platform }}.template_debug.dll release/addons/${{ env.project }}
         cp artifacts/Spout2/Binaries/x64/SpoutLibrary.dll release/addons/${{ env.project }}
         cp artifacts/${{ env.project }}.gdextension release/addons/${{ env.project }}
+        cp artifacts/README.md release/addons/${{env.project}}
     - name: save artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,8 +50,8 @@ jobs:
       
   release:
     name: Release Library
+    needs: [build]
     runs-on: windows-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -72,6 +72,7 @@ jobs:
         name: spout-gd.zip
         path: artifact
     - name: push release
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: ncipollo/release-action@v1
       with:
         artifacts: spout-gd.zip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,20 +5,18 @@ jobs:
     name: Build library
     runs-on: windows-latest
     steps:
-    - name: Install cmake
-      uses: crazy-max/ghaction-chocolatey@v3.0.0
-      with:
-        args: install cmake -y --installargs="ADD_CMAKE_TO_PATH=System"
-    - name: Install Python
-      uses: crazy-max/ghaction-chocolatey@v3.0.0
-      with:
-        args: install python311 -y --installargs="/quiet InstallAllUsers=1 PrependPath=1 Include_test=0"
-    - name: Install scons
-      run: pip install scons
     - name: Checkout
       uses: actions/checkout@v4
       with:
         submodules: 'true'
+    - name: Install cmake
+      uses: lukka/get-cmake@fix-issue-123
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Install scons
+      run: pip install scons
     - name: Build Spout Library
       working-directory: Spout2
       run: |
@@ -38,5 +36,10 @@ jobs:
     - name: save artifact
       uses: actions/upload-artifact@v3
       with:
-        name: spout-gd
+        name: spout-gd.zip
         path: artifact
+    - name: push release
+      uses: ncipollo/release-action@v1
+      if: ${{ github.ref == 'refs/heads/main' }}
+      with:
+        artifacts: spout-gd.zip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,11 +67,11 @@ jobs:
         merge-multiple: true      
     - name: prepare for packaging
       run: |
-        mkdir release\addons\spout-gd
-        cp artifacts/out/spout_gd.windows.template_release.dll release\addons\spout-gd
-        cp artifacts/out/spout_gd.windows.template_debug.dll release\addons\spout-gd
-        cp artifacts/Spout2/Binaries/x64/SpoutLibrary.dll release\addons\spout-gd
-        cp artifacts/spout_gd.gdextension release\addons\spout-gd
+        mkdir -p release/addons/spout-gd
+        cp artifacts/out/spout_gd.windows.template_release.dll release/addons/spout-gd
+        cp artifacts/out/spout_gd.windows.template_debug.dll release/addons/spout-gd
+        cp artifacts/Spout2/Binaries/x64/SpoutLibrary.dll release/addons/spout-gd
+        cp artifacts/spout_gd.gdextension release/addons/spout-gd
     - name: save artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,15 +12,20 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: 'true'
-    - id: caches
+    - name: Check Spout version
+      id: caches
       run: |
-        echo "spout_version=$(git rev-parse HEAD:Spout2)" >> $GITHUB_OUTPUT
+        "C:\Program Files\Git\bin\git.exe" rev-parse HEAD:Spout2
+        echo "spout_version=$("C:\Program Files\Git\bin\git.exe" rev-parse HEAD:Spout2)" >> $GITHUB_OUTPUT
+        echo "gdcpp_version=$("C:\Program Files\Git\bin\git.exe" rev-parse HEAD:godot-cpp)" >> $GITHUB_OUTPUT
     - name: Cache Spout build
       id: cache
       uses: actions/cache@v4
       with:
-        key: ${{ steps.caches.outputs.spout_version }}
-        path: ${{github.workspace}}/Spout2/Binaries/x64
+        key: "${{ steps.caches.outputs.spout_version }}:${{steps.caches.outputs.gdcpp_version}}"
+        path: |
+          ${{ github.workspace }}/Spout2
+          ${{ github.workspace }}/godot-cpp
     - name: Install cmake
       uses: lukka/get-cmake@fix-issue-123
     - name: Install Python
@@ -40,13 +45,11 @@ jobs:
     - name: save artifact
       uses: actions/upload-artifact@v3
       with:
-        name: spout_gd.windows.${{ matrix.release }}.dll
-        path: out/spout_gd.windows.${{ matrix.release }}.dll
-    - name: save artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: SpoutLibrary.dll
-        path: Spout2/Binaries/x64/SpoutLibrary.dll
+        name: spout2_${{ matrix.release }}
+        path: |
+          out/spout_gd.windows.${{ matrix.release }}.dll
+          Spout2/Binaries/x64/SpoutLibrary.dll
+          spout_gd.gdextension
       
   release:
     name: Release Library
@@ -55,17 +58,18 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: save artifact
+    - name: load artifacts
       uses: actions/download-artifact@v4
       with:
+        path: artifacts
         merge-multiple: true      
     - name: prepare for packaging
       run: |
-        mkdir artifact\addons\spout-gd
-        copy spout_gd.windows.template_release.dll artifact\addons\spout-gd
-        copy spout_gd.windows.template_debug.dll artifact\addons\spout-gd
-        copy SpoutLibrary.dll artifact\addons\spout-gd
-        copy spout_gd.gdextension artifact\addons\spout-gd
+        mkdir release\addons\spout-gd
+        copy artifacts/spout_gd.windows.template_release.dll release\addons\spout-gd
+        copy artifacts/spout_gd.windows.template_debug.dll release\addons\spout-gd
+        copy artifacts/SpoutLibrary.dll release\addons\spout-gd
+        copy artifacts/spout_gd.gdextension release\addons\spout-gd
     - name: save artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
             platform: windows
             arch: x86_64
     env:
-      SCONS_CACHE: ${{ github.workspace }}/scons_cache/${{ matrix.identifier }}
+      SCONS_CACHE: ${{ github.workspace }}/.scons_cache
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -32,15 +32,24 @@ jobs:
       id: caches
       shell: bash
       run: |
-        echo "cache_key=$(git rev-parse HEAD:Spout2):$(git rev-parse HEAD:godot-cpp)" >> $GITHUB_OUTPUT
+        echo "spout_version=$(git rev-parse HEAD:Spout2)"
     - name: Cache Dependency Builds
+      id: spout_cache
+      uses: actions/cache@v4
+      with:
+        key: "spout-${{ steps.caches.outputs.spout_version }}"
+        path: |
+          ${{ github.workspace }}/Spout2
+    - name: Cache Scons Builds
       id: cache
       uses: actions/cache@v4
       with:
-        key: ${{ steps.caches.outputs.cache_key }}
-        path: |
-          ${{ github.workspace }}/Spout2
-          ${{ env.SCONS_CACHE }}
+        key: ${{ matrix.identifier }}-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+            ${{ matrix.identifier }}-${{ github.ref }}-${{ github.sha }}
+            ${{ matrix.identifier }}-${{ github.ref }}
+            ${{ matrix.identifier }}
+        path: ${{ env.SCONS_CACHE }}
     - name: Install cmake
       uses: lukka/get-cmake@fix-issue-123
     - name: Install Python
@@ -50,13 +59,13 @@ jobs:
     - name: Install scons
       run: pip install scons
     - name: Build Spout Library
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.spout_cache.outputs.cache-hit != 'true'
       working-directory: Spout2
       run: |
         cmake -DSKIP_INSTALL_ALL=OFF -DSKIP_INSTALL_HEADERS=OFF -DSKIP_INSTALL_LIBRARIES=OFF -DSPOUT_BUILD_LIBRARY=ON --fresh .
         cmake --build . --clean-first
     - name: Build extension
-      run: scons target=${{ matrix.target }}
+      run: scons target='${{ matrix.target }}' platform='${{ matrix.platform }}' arch='${{ matrix.arch }}' -j2
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,8 @@ jobs:
     strategy:
       matrix:
         release: ['template_debug', 'template_release']
+    env:
+      SCONS_CACHE: ${{ github.workspace }}/scons_cache/${{ matrix.release }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -24,7 +26,7 @@ jobs:
         key: ${{ steps.caches.outputs.cache_key }}
         path: |
           ${{ github.workspace }}/Spout2
-          ${{ github.workspace }}/scons_cache
+          ${{ env.SCONS_CACHE }}
     - name: Install cmake
       uses: lukka/get-cmake@fix-issue-123
     - name: Install Python
@@ -41,8 +43,6 @@ jobs:
         cmake --build . --clean-first
     - name: Build spout-gd extension
       run: scons target=${{ matrix.release }}
-      env:
-        SCONS_CACHE: ${{ github.workspace }}/scons_cache
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
       id: caches
       shell: bash
       run: |
-        echo "spout_version=$(git rev-parse HEAD:Spout2)"
+        echo "spout_version=$(git rev-parse HEAD:Spout2)" >> $GITHUB_OUTPUT
     - name: Cache Dependency Builds
       id: spout_cache
       uses: actions/cache@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,9 @@ jobs:
   build:
     name: Build library
     runs-on: windows-latest
+    strategy:
+      matrix:
+        release: ['template_debug', 'template_release']
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -11,7 +14,7 @@ jobs:
         submodules: 'true'
     - id: caches
       run: |
-        echo "spout_version=${git rev-parse HEAD:Spout2}" >> $GITHUB_OUTPUT
+        echo "spout_version=$(git rev-parse HEAD:Spout2)" >> $GITHUB_OUTPUT
     - name: Cache Spout build
       id: cache
       uses: actions/cache@v4
@@ -32,16 +35,36 @@ jobs:
       run: |
         cmake -DSKIP_INSTALL_ALL=OFF -DSKIP_INSTALL_HEADERS=OFF -DSKIP_INSTALL_LIBRARIES=OFF -DSPOUT_BUILD_LIBRARY=ON --fresh .
         cmake --build . --clean-first
-    - name: Build spout-gd extension (Debug)
-      run: scons target=template_debug
-    - name: Build spout-gd extension (Release)
-      run: scons target=template_release
+    - name: Build spout-gd extension
+      run: scons target=${{ matrix.release }}
+    - name: save artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: spout_gd.windows.${{ matrix.release }}.dll
+        path: out/spout_gd.windows.${{ matrix.release }}.dll
+    - name: save artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: SpoutLibrary.dll
+        path: Spout2/Binaries/x64/SpoutLibrary.dll
+      
+  release:
+    name: Release Library
+    runs-on: windows-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: save artifact
+      uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true      
     - name: prepare for packaging
       run: |
         mkdir artifact\addons\spout-gd
-        copy out/spout_gd.windows.template_release.dll artifact\addons\spout-gd
-        copy out/spout_gd.windows.template_debug.dll artifact\addons\spout-gd
-        copy Spout2/Binaries/x64/SpoutLibrary.dll artifact\addons\spout-gd
+        copy spout_gd.windows.template_release.dll artifact\addons\spout-gd
+        copy spout_gd.windows.template_debug.dll artifact\addons\spout-gd
+        copy SpoutLibrary.dll artifact\addons\spout-gd
         copy spout_gd.gdextension artifact\addons\spout-gd
     - name: save artifact
       uses: actions/upload-artifact@v3
@@ -50,6 +73,5 @@ jobs:
         path: artifact
     - name: push release
       uses: ncipollo/release-action@v1
-      if: ${{ github.ref == 'refs/heads/main' }}
       with:
         artifacts: spout-gd.zip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: spout-gd.zip
-        path: artifact
+        path: release
     - name: push release
       if: ${{ github.ref == 'refs/heads/main' }}
       uses: ncipollo/release-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.obj
 *.dblite
 out/
+scons_cache

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 *.obj
 *.dblite
 out/
-scons_cache
+.scons_cache


### PR DESCRIPTION
working on tweaking the build pipeline some more

General goals
- simplify setup of cmake and python using actions instead of going through chocolately
- add cache steps to improve subsequent builds
- parallelize release and debug builds
- be able to create Releases because they don't expire like artifacts do